### PR TITLE
this plans

### DIFF
--- a/example-static-s3-website/certificates.tf
+++ b/example-static-s3-website/certificates.tf
@@ -1,9 +1,9 @@
 # Certificate for cloudfront distribution for web s3
 resource "aws_acm_certificate" "web_s3_cf_certificate" {
-    domain_name = module.example-web-s3-mod.acm_certificate_domain_name
-    validation_method = "EMAIL"
+  domain_name       = var.acm_certificate_domain_name
+  validation_method = "EMAIL"
 
-    lifecycle {
-        create_before_destroy = true
-    }
+  lifecycle {
+    create_before_destroy = true
+  }
 }

--- a/example-static-s3-website/cloudfront.tf
+++ b/example-static-s3-website/cloudfront.tf
@@ -1,65 +1,66 @@
 # Cloudfront distribution settings
 resource "aws_cloudfront_distribution" "web_s3_cloudfront_distribution" {
-    origin {
-        domain_name = aws_s3_bucket.web_s3_bucket.bucket_regional_domain_name
-        origin_id = module.example-web-s3-mod.cloudfront_distribution_origin_id
-    }
+  origin {
+    domain_name = aws_s3_bucket.web_s3_bucket.bucket_regional_domain_name
+    origin_id   = aws_s3_bucket.web_s3_bucket.bucket
 
     s3_origin_config {
-        origin_access_identity = aws_cloudfront_origin_access_identity.web_s3_cloudfront_origin_access_identity.id
+      origin_access_identity = aws_cloudfront_origin_access_identity.web_s3_cloudfront_origin_access_identity.cloudfront_access_identity_path
+    }
+  }
+
+  aliases = [
+    "${var.acm_certificate_domain_name}",
+    "www.${var.acm_certificate_domain_name}"
+  ]
+
+  enabled             = true
+  is_ipv6_enabled     = true
+  comment             = "web s3 cloudfront distribution"
+  default_root_object = "index.html"
+
+  logging_config {
+    include_cookies = false
+    bucket          = "${aws_s3_bucket.web_s3_bucket.bucket}.s3.amazonaws.com"
+    prefix          = "cloudfront/"
+  }
+
+  default_cache_behavior {
+    allowed_methods  = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
+    cached_methods   = ["GET", "HEAD"]
+    target_origin_id = aws_s3_bucket.web_s3_bucket.bucket
+
+    forwarded_values {
+      query_string = false
+
+      cookies {
+        forward = "none"
+      }
     }
 
-    aliases = [
-        "${module.example-web-s3-mod.acm_certificate_domain_name}",
-        "www.${module.example-web-s3-mod.acm_certificate_domain_name}"
-    ]
+    viewer_protocol_policy = "allow-all"
+    min_ttl                = 0
+    default_ttl            = 3600
+    max_ttl                = 86400
+  }
 
-    enabled = true
-    is_ipv6_enabled = true
-    comment = "web s3 cloudfront distribution"
-    default_root_object = "index.html"
+  price_class = "PriceClass_100"
 
-    logging_config {
-        include_cookies = false
-        bucket = "${module.example-web-s3-mod.logging_bucket_name}.s3.amazonaws.com"
-        prefix = "cloudfront/"
+  restrictions {
+    geo_restriction {
+      restriction_type = "whitelist"
+      locations = [
+        "US"
+      ]
     }
+  }
 
-    default_cache_behavior {
-        allowed_methods = ["DELETE","GET","HEAD","OPTIONS","PATCH","POST","PUT"]
-        cached_methods = ["GET","HEAD"]
-        target_origin_id = module.example-web-s3-mod.cloudfront_distribution_origin_id
-
-        forwarded_values {
-            query_string = false
-
-            cookies {
-                forward = "none"
-            }
-        }
-
-        viewer_protocol_policy = "allow-all"
-        min_ttl = 0
-        default_ttl = 3600
-        max_ttl = 86400
-    }
-
-    price_class = "PriceClass_100"
-
-    restrictions {
-        geo_restriction {
-            restriction_type = "whitelist"
-            locations = [
-                "US"
-            ]
-        }
-    }
-
-    viewer_certificate {
-        cloudfront_default_certificate = true
-    }
+  viewer_certificate {
+    cloudfront_default_certificate = false
+    acm_certificate_arn            = aws_acm_certificate.web_s3_cf_certificate.arn
+  }
 }
 
 resource "aws_cloudfront_origin_access_identity" "web_s3_cloudfront_origin_access_identity" {
-    comment = "web s3 OAI to access bucket"
+  comment = "web s3 OAI to access bucket"
 }

--- a/example-static-s3-website/examples/main.tf
+++ b/example-static-s3-website/examples/main.tf
@@ -1,16 +1,12 @@
 provider "aws" {
-    region = "us-east-1"
-    profile = "default"
-    assume_role {
-        role_arn = "arn:aws:iam::ACCOUNT_ID_HERE:user/USER_NAME_HERE"
-    }
+  region = "us-east-1"
 }
 
 module "example-web-s3-mod" {
-    source = "../"
+  source = "../"
 
-    web_s3_bucket_name = "example-web-s3-bucket"
-    logging_bucket_name = "example-logging-bucket"
-    cloudfront_distribution_origin_id = "example-cf-dist-origin-id"
-    acm_certificate_domain_name = "example.mydomain.com"
+  web_s3_bucket_name                = "example-web-s3-bucket"
+  logging_bucket_name               = "example-logging-bucket"
+  cloudfront_distribution_origin_id = "example-cf-dist-origin-id"
+  acm_certificate_domain_name       = "example.mydomain.com"
 }

--- a/example-static-s3-website/kms.tf
+++ b/example-static-s3-website/kms.tf
@@ -1,9 +1,9 @@
 resource "aws_kms_key" "web_s3_kms_key" {
-    description = "web s3 kms key"
-    deletion_window_in_days = 10
+  description             = "web s3 kms key"
+  deletion_window_in_days = 10
 }
 
 resource "aws_kms_key" "logging_kms_key" {
-    description = "web s3 kms key"
-    deletion_window_in_days = 10
+  description             = "web s3 kms key"
+  deletion_window_in_days = 10
 }

--- a/example-static-s3-website/s3.tf
+++ b/example-static-s3-website/s3.tf
@@ -1,203 +1,204 @@
 ### All S3 bucket resources
 # WEB S3 bucket resources
 resource "aws_s3_bucket" "web_s3_bucket" {
-    bucket = module.example-web-s3-mod.web_s3_bucket_name
+  bucket = var.web_s3_bucket_name
 }
 
 resource "aws_s3_bucket_acl" "web_s3_bucket_acl" {
-    bucket = aws_s3_bucket.web_s3_bucket.id
-    acl = "private"
+  bucket = aws_s3_bucket.web_s3_bucket.id
+  acl    = "private"
 }
 
 data "aws_iam_policy_document" "web_s3_iam_policy_document" {
-    statement {
-        principals {
-            type = "AWS"
-            identifiers = [
-                aws_cloudfront_origin_access_identity.web_s3_cloudfront_origin_access_identity.id
-            ]
-        }
-
-        actions = [
-            "s3:GetObject"
-        ]
-
-        resources = [
-            "arn:aws:s3:::${module.example-web-s3-mod.web_s3_bucket_name}/*"
-        ]
+  statement {
+    principals {
+      type = "AWS"
+      identifiers = [
+        aws_cloudfront_origin_access_identity.web_s3_cloudfront_origin_access_identity.id,
+      ]
     }
+
+    actions = [
+      "s3:GetObject",
+    ]
+
+    resources = [
+      "${aws_s3_bucket.web_s3_bucket.arn}/*",
+    ]
+  }
 }
 
 resource "aws_s3_bucket_policy" "web_s3_bucket_policy" {
-    bucket = aws_s3_bucket.web_s3_bucket.id
-    policy = data.aws_iam_policy_document.web_s3_iam_policy_document.json
+  bucket = aws_s3_bucket.web_s3_bucket.id
+  policy = data.aws_iam_policy_document.web_s3_iam_policy_document.json
 }
 
 resource "aws_s3_bucket_server_side_encryption_configuration" "web_s3_side_encrption_configuration" {
-    bucket = aws_s3_bucket.web_s3_bucket.id
+  bucket = aws_s3_bucket.web_s3_bucket.id
 
-    rule {
-        apply_server_side_encryption_by_default {
-            kms_master_key_id = aws_kms_key.web_s3_kms_key.arn
-            sse_algorithm = "aws:kms"
-        }
+  rule {
+    apply_server_side_encryption_by_default {
+      kms_master_key_id = aws_kms_key.web_s3_kms_key.arn
+      sse_algorithm     = "aws:kms"
     }
+  }
 }
 
-resource "aws_s3_bucket_website_configuration" "web_s3_website_configuration" {
-    bucket = aws_s3_bucket.web_s3_bucket.bucket
+# resource "aws_s3_bucket_website_configuration" "web_s3_website_configuration" {
+#   bucket = aws_s3_bucket.web_s3_bucket.bucket
 
-    index_document {
-        suffix = "index.html"
-    }
+#   index_document {
+#     suffix = "index.html"
+#   }
 
-    error_document {
-        suffix = "error.html"
-    }
-}
+#   error_document {
+#     suffix = "error.html"
+#   }
+# }
 
 resource "aws_s3_bucket_versioning" "web_s3_versioning" {
-    bucket = aws_s3_bucket.web_s3_bucket.id
-    versioning_configuration {
-        status = "Enabled"
-    }
+  bucket = aws_s3_bucket.web_s3_bucket.id
+  versioning_configuration {
+    status = "Enabled"
+  }
 }
 
 resource "aws_s3_bucket_public_access_block" "web_s3_public_access_block" {
-    bucket = aws_s3_bucket.web_s3_bucket.id
+  bucket = aws_s3_bucket.web_s3_bucket.id
 
-    block_public_acls = true
-    block_public_policy = true
+  block_public_acls   = true
+  block_public_policy = true
 }
 
 resource "aws_s3_bucket_logging" "web_s3_logging" {
-    bucket = aws_s3_bucket.web_s3_bucket.id
+  bucket = aws_s3_bucket.web_s3_bucket.id
 
-    target_bucket = aws_s3_bucket.logging_bucket.id
-    target_prefix = "s3/web-s3/"
+  target_bucket = aws_s3_bucket.logging_bucket.id
+  target_prefix = "s3/web-s3/"
 }
 
 resource "aws_s3_bucket_cors_configuration" "web_s3_cors_configuration" {
-    bucket = aws_s3_bucket.web_s3_bucket.bucket
+  bucket = aws_s3_bucket.web_s3_bucket.bucket
 
-    cors_rule {
-        allowed_headers = ["*"]
-        allowed_methods = ["PUT","POST"]
-        allowed_origins = ["${module.example-web-s3-mod.acm_certificate_domain_name}"]
-        expose_headers = ["ETag"]
-        max_age_seconds = 3000
-    }
+  cors_rule {
+    allowed_headers = ["*"]
+    allowed_methods = ["PUT", "POST"]
+    allowed_origins = ["${var.acm_certificate_domain_name}"]
+    expose_headers  = ["ETag"]
+    max_age_seconds = 3000
+  }
 
-    cors_rule {
-        allowed_methods = ["GET"]
-        allowed_origins = ["*"]
-    }
+  cors_rule {
+    allowed_methods = ["GET"]
+    allowed_origins = ["*"]
+  }
 }
 
 resource "aws_s3_bucket_lifecycle_configuration" "web_s3_lifecycle_configuration" {
-    bucket = aws_s3_bucket.web_s3_bucket.bucket
-    depends_on = [aws_s3_bucket.web_s3_versioning]
+  bucket     = aws_s3_bucket.web_s3_bucket.bucket
+  depends_on = [aws_s3_bucket_versioning.web_s3_versioning]
 
-    rule {
-        id = "non-current-web-s3-versions-rule"
-
-        noncurrent_version_expiration {
-            noncurrent_days = 1
-        }
-    }
-
+  rule {
+    id     = "non-current-web-s3-versions-rule"
     status = "Enabled"
+
+    noncurrent_version_expiration {
+      noncurrent_days = 1
+    }
+  }
+
 }
 
 # Logging bucket resources
 resource "aws_s3_bucket" "logging_bucket" {
-    bucket = module.example-web-s3-mod.logging_bucket_name
+  bucket = var.logging_bucket_name
 }
 
 resource "aws_s3_bucket_acl" "logging_bucket_acl" {
-    bucket = aws_s3_bucket.logging_bucket.id
-    acl = module.example-web-s3-mod.logging_bucket_acl
+  bucket = aws_s3_bucket.logging_bucket.id
+  acl    = "private"
 }
 
 data "aws_iam_policy_document" "logging_bucket_iam_policy_document" {
-    statement {
-        principals {
-            type = "AWS"
-            identifiers = [
-                aws_cloudfront_distribution.web_s3_cloudfront_distribution.id,
-                aws_s3_bucket.web_s3_bucket.id
-            ]
-
-            actions = [
-                "s3:PubObject"
-            ]
-
-            resource = [
-                aws_s3_bucket.logging_bucket.arn,
-                "${aws_s3_bucket.logging_bucket.arn}/*"
-            ]
-        }
+  statement {
+    principals {
+      type = "AWS"
+      identifiers = [
+        aws_cloudfront_distribution.web_s3_cloudfront_distribution.id,
+        aws_s3_bucket.web_s3_bucket.id,
+      ]
     }
+
+    actions = [
+      "s3:PutObject",
+    ]
+
+    resources = [
+      aws_s3_bucket.logging_bucket.arn,
+      "${aws_s3_bucket.logging_bucket.arn}/*",
+    ]
+  }
 }
 
+
 resource "aws_s3_bucket_policy" "logging_bucket_policy" {
-    bucket = aws_s3_bucket.logging_bucket.id
-    policy = aws_iam_policy_document.logging_bucket_iam_policy_document.json
+  bucket = aws_s3_bucket.logging_bucket.id
+  policy = data.aws_iam_policy_document.logging_bucket_iam_policy_document.json
 }
 
 resource "aws_s3_bucket_server_side_encryption_configuration" "logging_side_encrption_configuration" {
-    bucket = aws_s3_bucket.logging_bucket.id
+  bucket = aws_s3_bucket.logging_bucket.id
 
-    rule {
-        apply_server_side_encryption_by_default {
-            kms_master_key_id = aws_kms_key.logging_kms_key.arn
-            sse_algorithm = "aws:kms"
-        }
+  rule {
+    apply_server_side_encryption_by_default {
+      kms_master_key_id = aws_kms_key.logging_kms_key.arn
+      sse_algorithm     = "aws:kms"
     }
+  }
 }
 
 resource "aws_s3_bucket_versioning" "logging_versioning" {
-    bucket = aws_s3_bucket.logging_bucket.id
-    versioning_configuration {
-        status = "Enabled"
-    }
+  bucket = aws_s3_bucket.logging_bucket.id
+  versioning_configuration {
+    status = "Enabled"
+  }
 }
 
 resource "aws_s3_bucket_public_access_block" "logging_public_access_block" {
-    bucket = aws_s3_bucket.logging_bucket.id
+  bucket = aws_s3_bucket.logging_bucket.id
 
-    block_public_acls = true
-    block_public_policy = true
+  block_public_acls   = true
+  block_public_policy = true
 }
 
 resource "aws_s3_bucket_logging" "logging_logging" {
-    bucket = aws_s3_bucket.logging_bucket.id
+  bucket = aws_s3_bucket.logging_bucket.id
 
-    target_bucket = aws_s3_bucket.logging_bucket.id
-    target_prefix = "s3/logging-bucket/"
+  target_bucket = aws_s3_bucket.logging_bucket.id
+  target_prefix = "s3/logging-bucket/"
 }
 
 resource "aws_s3_bucket_lifecycle_configuration" "logging_lifecycle_configuration" {
-    bucket = aws_s3_bucket.logging_bucket.bucket
-    depends_on = [aws_s3_bucket.logging_versioning]
+  bucket     = aws_s3_bucket.logging_bucket.bucket
+  depends_on = [aws_s3_bucket_versioning.logging_versioning]
 
-    rule {
-        id = "non-current-logging-bucket-versions-rule"
+  rule {
+    id     = "non-current-logging-bucket-versions-rule"
+    status = "Enabled"
 
-        noncurrent_version_expiration {
-            noncurrent_days = 90
-        }
-
-        noncurrent_version_transition {
-            noncurrent_days = 30
-            storage_class = "STANDARD_IA"
-        }
-
-        noncurrent_version_transition {
-            noncurrent_days = 60
-            storage_class = "GLACIER"
-        }
+    noncurrent_version_expiration {
+      noncurrent_days = 90
     }
 
-    status = "Enabled"
+    noncurrent_version_transition {
+      noncurrent_days = 30
+      storage_class   = "STANDARD_IA"
+    }
+
+    noncurrent_version_transition {
+      noncurrent_days = 60
+      storage_class   = "GLACIER"
+    }
+  }
+
 }

--- a/example-static-s3-website/variables.tf
+++ b/example-static-s3-website/variables.tf
@@ -1,24 +1,24 @@
 # Main vars for web s3 module
 variable "web_s3_bucket_name" {
-    type        = string
-    default     = ""
-    description = "Name of the bucket hosting the static website"
+  type        = string
+  default     = ""
+  description = "Name of the bucket hosting the static website"
 }
 
 variable "logging_bucket_name" {
-    type = string
-    default = ""
-    description = "Name of the bucket that holds access logs for the web s3 bucket"
+  type        = string
+  default     = ""
+  description = "Name of the bucket that holds access logs for the web s3 bucket"
 }
 
 variable "cloudfront_distribution_origin_id" {
-    type = string
-    default = ""
-    description = "origin identifier for cloudfront distribution web s3 bucket"
+  type        = string
+  default     = ""
+  description = "origin identifier for cloudfront distribution web s3 bucket"
 }
 
 variable "acm_certificate_domain_name" {
-    type = string
-    default = ""
-    description = "domain name for the certificate of the website"
+  type        = string
+  default     = ""
+  description = "domain name for the certificate of the website"
 }

--- a/example-static-s3-website/versions.tf
+++ b/example-static-s3-website/versions.tf
@@ -1,11 +1,10 @@
 terraform {
-    required_version = "~> 1.1.9"
+  required_version = "~> 1.1.9"
 
-    required_providers {
-      aws = {
-          source = "hashicorp/aws"
-          version = "~> 4.12.1"
-      }
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.12.1"
     }
-
+  }
 }


### PR DESCRIPTION
```shell
❯ terraform plan

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create
 <= read (data resources)

Terraform will perform the following actions:

  # module.example-web-s3-mod.data.aws_iam_policy_document.logging_bucket_iam_policy_document will be read during apply
  # (config refers to values not yet known)
 <= data "aws_iam_policy_document" "logging_bucket_iam_policy_document"  {
      + id   = (known after apply)
      + json = (known after apply)

      + statement {
          + actions   = [
              + "s3:PutObject",
            ]
          + resources = [
              + (known after apply),
              + (known after apply),
            ]

          + principals {
              + identifiers = [
                  + (known after apply),
                  + (known after apply),
                ]
              + type        = "AWS"
            }
        }
    }

  # module.example-web-s3-mod.data.aws_iam_policy_document.web_s3_iam_policy_document will be read during apply
  # (config refers to values not yet known)
 <= data "aws_iam_policy_document" "web_s3_iam_policy_document"  {
      + id   = (known after apply)
      + json = (known after apply)

      + statement {
          + actions   = [
              + "s3:GetObject",
            ]
          + resources = [
              + (known after apply),
            ]

          + principals {
              + identifiers = [
                  + (known after apply),
                ]
              + type        = "AWS"
            }
        }
    }

  # module.example-web-s3-mod.aws_acm_certificate.web_s3_cf_certificate will be created
  + resource "aws_acm_certificate" "web_s3_cf_certificate" {
      + arn                       = (known after apply)
      + domain_name               = "example.mydomain.com"
      + domain_validation_options = (known after apply)
      + id                        = (known after apply)
      + status                    = (known after apply)
      + subject_alternative_names = [
          + "example.mydomain.com",
        ]
      + tags_all                  = (known after apply)
      + validation_emails         = (known after apply)
      + validation_method         = "EMAIL"
    }

  # module.example-web-s3-mod.aws_cloudfront_distribution.web_s3_cloudfront_distribution will be created
  + resource "aws_cloudfront_distribution" "web_s3_cloudfront_distribution" {
      + aliases                        = [
          + "example.mydomain.com",
          + "www.example.mydomain.com",
        ]
      + arn                            = (known after apply)
      + caller_reference               = (known after apply)
      + comment                        = "web s3 cloudfront distribution"
      + default_root_object            = "index.html"
      + domain_name                    = (known after apply)
      + enabled                        = true
      + etag                           = (known after apply)
      + hosted_zone_id                 = (known after apply)
      + http_version                   = "http2"
      + id                             = (known after apply)
      + in_progress_validation_batches = (known after apply)
      + is_ipv6_enabled                = true
      + last_modified_time             = (known after apply)
      + price_class                    = "PriceClass_100"
      + retain_on_delete               = false
      + status                         = (known after apply)
      + tags_all                       = (known after apply)
      + trusted_key_groups             = (known after apply)
      + trusted_signers                = (known after apply)
      + wait_for_deployment            = true

      + default_cache_behavior {
          + allowed_methods        = [
              + "DELETE",
              + "GET",
              + "HEAD",
              + "OPTIONS",
              + "PATCH",
              + "POST",
              + "PUT",
            ]
          + cached_methods         = [
              + "GET",
              + "HEAD",
            ]
          + compress               = false
          + default_ttl            = 3600
          + max_ttl                = 86400
          + min_ttl                = 0
          + target_origin_id       = "example-web-s3-bucket"
          + trusted_key_groups     = (known after apply)
          + trusted_signers        = (known after apply)
          + viewer_protocol_policy = "allow-all"

          + forwarded_values {
              + headers                 = (known after apply)
              + query_string            = false
              + query_string_cache_keys = (known after apply)

              + cookies {
                  + forward           = "none"
                  + whitelisted_names = (known after apply)
                }
            }
        }

      + logging_config {
          + bucket          = "example-web-s3-bucket.s3.amazonaws.com"
          + include_cookies = false
          + prefix          = "cloudfront/"
        }

      + origin {
          + connection_attempts = 3
          + connection_timeout  = 10
          + domain_name         = (known after apply)
          + origin_id           = "example-web-s3-bucket"

          + s3_origin_config {
              + origin_access_identity = (known after apply)
            }
        }

      + restrictions {
          + geo_restriction {
              + locations        = [
                  + "US",
                ]
              + restriction_type = "whitelist"
            }
        }

      + viewer_certificate {
          + acm_certificate_arn            = (known after apply)
          + cloudfront_default_certificate = false
          + minimum_protocol_version       = "TLSv1"
        }
    }

  # module.example-web-s3-mod.aws_cloudfront_origin_access_identity.web_s3_cloudfront_origin_access_identity will be created
  + resource "aws_cloudfront_origin_access_identity" "web_s3_cloudfront_origin_access_identity" {
      + caller_reference                = (known after apply)
      + cloudfront_access_identity_path = (known after apply)
      + comment                         = "web s3 OAI to access bucket"
      + etag                            = (known after apply)
      + iam_arn                         = (known after apply)
      + id                              = (known after apply)
      + s3_canonical_user_id            = (known after apply)
    }

  # module.example-web-s3-mod.aws_kms_key.logging_kms_key will be created
  + resource "aws_kms_key" "logging_kms_key" {
      + arn                                = (known after apply)
      + bypass_policy_lockout_safety_check = false
      + customer_master_key_spec           = "SYMMETRIC_DEFAULT"
      + deletion_window_in_days            = 10
      + description                        = "web s3 kms key"
      + enable_key_rotation                = false
      + id                                 = (known after apply)
      + is_enabled                         = true
      + key_id                             = (known after apply)
      + key_usage                          = "ENCRYPT_DECRYPT"
      + multi_region                       = (known after apply)
      + policy                             = (known after apply)
      + tags_all                           = (known after apply)
    }

  # module.example-web-s3-mod.aws_kms_key.web_s3_kms_key will be created
  + resource "aws_kms_key" "web_s3_kms_key" {
      + arn                                = (known after apply)
      + bypass_policy_lockout_safety_check = false
      + customer_master_key_spec           = "SYMMETRIC_DEFAULT"
      + deletion_window_in_days            = 10
      + description                        = "web s3 kms key"
      + enable_key_rotation                = false
      + id                                 = (known after apply)
      + is_enabled                         = true
      + key_id                             = (known after apply)
      + key_usage                          = "ENCRYPT_DECRYPT"
      + multi_region                       = (known after apply)
      + policy                             = (known after apply)
      + tags_all                           = (known after apply)
    }

  # module.example-web-s3-mod.aws_s3_bucket.logging_bucket will be created
  + resource "aws_s3_bucket" "logging_bucket" {
      + acceleration_status         = (known after apply)
      + acl                         = (known after apply)
      + arn                         = (known after apply)
      + bucket                      = "example-logging-bucket"
      + bucket_domain_name          = (known after apply)
      + bucket_regional_domain_name = (known after apply)
      + force_destroy               = false
      + hosted_zone_id              = (known after apply)
      + id                          = (known after apply)
      + object_lock_enabled         = (known after apply)
      + policy                      = (known after apply)
      + region                      = (known after apply)
      + request_payer               = (known after apply)
      + tags_all                    = (known after apply)
      + website_domain              = (known after apply)
      + website_endpoint            = (known after apply)

      + cors_rule {
          + allowed_headers = (known after apply)
          + allowed_methods = (known after apply)
          + allowed_origins = (known after apply)
          + expose_headers  = (known after apply)
          + max_age_seconds = (known after apply)
        }

      + grant {
          + id          = (known after apply)
          + permissions = (known after apply)
          + type        = (known after apply)
          + uri         = (known after apply)
        }

      + lifecycle_rule {
          + abort_incomplete_multipart_upload_days = (known after apply)
          + enabled                                = (known after apply)
          + id                                     = (known after apply)
          + prefix                                 = (known after apply)
          + tags                                   = (known after apply)

          + expiration {
              + date                         = (known after apply)
              + days                         = (known after apply)
              + expired_object_delete_marker = (known after apply)
            }

          + noncurrent_version_expiration {
              + days = (known after apply)
            }

          + noncurrent_version_transition {
              + days          = (known after apply)
              + storage_class = (known after apply)
            }

          + transition {
              + date          = (known after apply)
              + days          = (known after apply)
              + storage_class = (known after apply)
            }
        }

      + logging {
          + target_bucket = (known after apply)
          + target_prefix = (known after apply)
        }

      + object_lock_configuration {
          + object_lock_enabled = (known after apply)

          + rule {
              + default_retention {
                  + days  = (known after apply)
                  + mode  = (known after apply)
                  + years = (known after apply)
                }
            }
        }

      + replication_configuration {
          + role = (known after apply)

          + rules {
              + delete_marker_replication_status = (known after apply)
              + id                               = (known after apply)
              + prefix                           = (known after apply)
              + priority                         = (known after apply)
              + status                           = (known after apply)

              + destination {
                  + account_id         = (known after apply)
                  + bucket             = (known after apply)
                  + replica_kms_key_id = (known after apply)
                  + storage_class      = (known after apply)

                  + access_control_translation {
                      + owner = (known after apply)
                    }

                  + metrics {
                      + minutes = (known after apply)
                      + status  = (known after apply)
                    }

                  + replication_time {
                      + minutes = (known after apply)
                      + status  = (known after apply)
                    }
                }

              + filter {
                  + prefix = (known after apply)
                  + tags   = (known after apply)
                }

              + source_selection_criteria {
                  + sse_kms_encrypted_objects {
                      + enabled = (known after apply)
                    }
                }
            }
        }

      + server_side_encryption_configuration {
          + rule {
              + bucket_key_enabled = (known after apply)

              + apply_server_side_encryption_by_default {
                  + kms_master_key_id = (known after apply)
                  + sse_algorithm     = (known after apply)
                }
            }
        }

      + versioning {
          + enabled    = (known after apply)
          + mfa_delete = (known after apply)
        }

      + website {
          + error_document           = (known after apply)
          + index_document           = (known after apply)
          + redirect_all_requests_to = (known after apply)
          + routing_rules            = (known after apply)
        }
    }

  # module.example-web-s3-mod.aws_s3_bucket.web_s3_bucket will be created
  + resource "aws_s3_bucket" "web_s3_bucket" {
      + acceleration_status         = (known after apply)
      + acl                         = (known after apply)
      + arn                         = (known after apply)
      + bucket                      = "example-web-s3-bucket"
      + bucket_domain_name          = (known after apply)
      + bucket_regional_domain_name = (known after apply)
      + force_destroy               = false
      + hosted_zone_id              = (known after apply)
      + id                          = (known after apply)
      + object_lock_enabled         = (known after apply)
      + policy                      = (known after apply)
      + region                      = (known after apply)
      + request_payer               = (known after apply)
      + tags_all                    = (known after apply)
      + website_domain              = (known after apply)
      + website_endpoint            = (known after apply)

      + cors_rule {
          + allowed_headers = (known after apply)
          + allowed_methods = (known after apply)
          + allowed_origins = (known after apply)
          + expose_headers  = (known after apply)
          + max_age_seconds = (known after apply)
        }

      + grant {
          + id          = (known after apply)
          + permissions = (known after apply)
          + type        = (known after apply)
          + uri         = (known after apply)
        }

      + lifecycle_rule {
          + abort_incomplete_multipart_upload_days = (known after apply)
          + enabled                                = (known after apply)
          + id                                     = (known after apply)
          + prefix                                 = (known after apply)
          + tags                                   = (known after apply)

          + expiration {
              + date                         = (known after apply)
              + days                         = (known after apply)
              + expired_object_delete_marker = (known after apply)
            }

          + noncurrent_version_expiration {
              + days = (known after apply)
            }

          + noncurrent_version_transition {
              + days          = (known after apply)
              + storage_class = (known after apply)
            }

          + transition {
              + date          = (known after apply)
              + days          = (known after apply)
              + storage_class = (known after apply)
            }
        }

      + logging {
          + target_bucket = (known after apply)
          + target_prefix = (known after apply)
        }

      + object_lock_configuration {
          + object_lock_enabled = (known after apply)

          + rule {
              + default_retention {
                  + days  = (known after apply)
                  + mode  = (known after apply)
                  + years = (known after apply)
                }
            }
        }

      + replication_configuration {
          + role = (known after apply)

          + rules {
              + delete_marker_replication_status = (known after apply)
              + id                               = (known after apply)
              + prefix                           = (known after apply)
              + priority                         = (known after apply)
              + status                           = (known after apply)

              + destination {
                  + account_id         = (known after apply)
                  + bucket             = (known after apply)
                  + replica_kms_key_id = (known after apply)
                  + storage_class      = (known after apply)

                  + access_control_translation {
                      + owner = (known after apply)
                    }

                  + metrics {
                      + minutes = (known after apply)
                      + status  = (known after apply)
                    }

                  + replication_time {
                      + minutes = (known after apply)
                      + status  = (known after apply)
                    }
                }

              + filter {
                  + prefix = (known after apply)
                  + tags   = (known after apply)
                }

              + source_selection_criteria {
                  + sse_kms_encrypted_objects {
                      + enabled = (known after apply)
                    }
                }
            }
        }

      + server_side_encryption_configuration {
          + rule {
              + bucket_key_enabled = (known after apply)

              + apply_server_side_encryption_by_default {
                  + kms_master_key_id = (known after apply)
                  + sse_algorithm     = (known after apply)
                }
            }
        }

      + versioning {
          + enabled    = (known after apply)
          + mfa_delete = (known after apply)
        }

      + website {
          + error_document           = (known after apply)
          + index_document           = (known after apply)
          + redirect_all_requests_to = (known after apply)
          + routing_rules            = (known after apply)
        }
    }

  # module.example-web-s3-mod.aws_s3_bucket_acl.logging_bucket_acl will be created
  + resource "aws_s3_bucket_acl" "logging_bucket_acl" {
      + acl    = "private"
      + bucket = (known after apply)
      + id     = (known after apply)

      + access_control_policy {
          + grant {
              + permission = (known after apply)

              + grantee {
                  + display_name  = (known after apply)
                  + email_address = (known after apply)
                  + id            = (known after apply)
                  + type          = (known after apply)
                  + uri           = (known after apply)
                }
            }

          + owner {
              + display_name = (known after apply)
              + id           = (known after apply)
            }
        }
    }

  # module.example-web-s3-mod.aws_s3_bucket_acl.web_s3_bucket_acl will be created
  + resource "aws_s3_bucket_acl" "web_s3_bucket_acl" {
      + acl    = "private"
      + bucket = (known after apply)
      + id     = (known after apply)

      + access_control_policy {
          + grant {
              + permission = (known after apply)

              + grantee {
                  + display_name  = (known after apply)
                  + email_address = (known after apply)
                  + id            = (known after apply)
                  + type          = (known after apply)
                  + uri           = (known after apply)
                }
            }

          + owner {
              + display_name = (known after apply)
              + id           = (known after apply)
            }
        }
    }

  # module.example-web-s3-mod.aws_s3_bucket_cors_configuration.web_s3_cors_configuration will be created
  + resource "aws_s3_bucket_cors_configuration" "web_s3_cors_configuration" {
      + bucket = "example-web-s3-bucket"
      + id     = (known after apply)

      + cors_rule {
          + allowed_headers = [
              + "*",
            ]
          + allowed_methods = [
              + "POST",
              + "PUT",
            ]
          + allowed_origins = [
              + "example.mydomain.com",
            ]
          + expose_headers  = [
              + "ETag",
            ]
          + max_age_seconds = 3000
        }
      + cors_rule {
          + allowed_headers = []
          + allowed_methods = [
              + "GET",
            ]
          + allowed_origins = [
              + "*",
            ]
          + expose_headers  = []
        }
    }

  # module.example-web-s3-mod.aws_s3_bucket_lifecycle_configuration.logging_lifecycle_configuration will be created
  + resource "aws_s3_bucket_lifecycle_configuration" "logging_lifecycle_configuration" {
      + bucket = "example-logging-bucket"
      + id     = (known after apply)

      + rule {
          + id     = "non-current-logging-bucket-versions-rule"
          + status = "Enabled"

          + noncurrent_version_expiration {
              + noncurrent_days = 90
            }

          + noncurrent_version_transition {
              + noncurrent_days = 30
              + storage_class   = "STANDARD_IA"
            }
          + noncurrent_version_transition {
              + noncurrent_days = 60
              + storage_class   = "GLACIER"
            }
        }
    }

  # module.example-web-s3-mod.aws_s3_bucket_lifecycle_configuration.web_s3_lifecycle_configuration will be created
  + resource "aws_s3_bucket_lifecycle_configuration" "web_s3_lifecycle_configuration" {
      + bucket = "example-web-s3-bucket"
      + id     = (known after apply)

      + rule {
          + id     = "non-current-web-s3-versions-rule"
          + status = "Enabled"

          + noncurrent_version_expiration {
              + noncurrent_days = 1
            }
        }
    }

  # module.example-web-s3-mod.aws_s3_bucket_logging.logging_logging will be created
  + resource "aws_s3_bucket_logging" "logging_logging" {
      + bucket        = (known after apply)
      + id            = (known after apply)
      + target_bucket = (known after apply)
      + target_prefix = "s3/logging-bucket/"
    }

  # module.example-web-s3-mod.aws_s3_bucket_logging.web_s3_logging will be created
  + resource "aws_s3_bucket_logging" "web_s3_logging" {
      + bucket        = (known after apply)
      + id            = (known after apply)
      + target_bucket = (known after apply)
      + target_prefix = "s3/web-s3/"
    }

  # module.example-web-s3-mod.aws_s3_bucket_policy.logging_bucket_policy will be created
  + resource "aws_s3_bucket_policy" "logging_bucket_policy" {
      + bucket = (known after apply)
      + id     = (known after apply)
      + policy = (known after apply)
    }

  # module.example-web-s3-mod.aws_s3_bucket_policy.web_s3_bucket_policy will be created
  + resource "aws_s3_bucket_policy" "web_s3_bucket_policy" {
      + bucket = (known after apply)
      + id     = (known after apply)
      + policy = (known after apply)
    }

  # module.example-web-s3-mod.aws_s3_bucket_public_access_block.logging_public_access_block will be created
  + resource "aws_s3_bucket_public_access_block" "logging_public_access_block" {
      + block_public_acls       = true
      + block_public_policy     = true
      + bucket                  = (known after apply)
      + id                      = (known after apply)
      + ignore_public_acls      = false
      + restrict_public_buckets = false
    }

  # module.example-web-s3-mod.aws_s3_bucket_public_access_block.web_s3_public_access_block will be created
  + resource "aws_s3_bucket_public_access_block" "web_s3_public_access_block" {
      + block_public_acls       = true
      + block_public_policy     = true
      + bucket                  = (known after apply)
      + id                      = (known after apply)
      + ignore_public_acls      = false
      + restrict_public_buckets = false
    }

  # module.example-web-s3-mod.aws_s3_bucket_server_side_encryption_configuration.logging_side_encrption_configuration will be created
  + resource "aws_s3_bucket_server_side_encryption_configuration" "logging_side_encrption_configuration" {
      + bucket = (known after apply)
      + id     = (known after apply)

      + rule {
          + apply_server_side_encryption_by_default {
              + kms_master_key_id = (known after apply)
              + sse_algorithm     = "aws:kms"
            }
        }
    }

  # module.example-web-s3-mod.aws_s3_bucket_server_side_encryption_configuration.web_s3_side_encrption_configuration will be created
  + resource "aws_s3_bucket_server_side_encryption_configuration" "web_s3_side_encrption_configuration" {
      + bucket = (known after apply)
      + id     = (known after apply)

      + rule {
          + apply_server_side_encryption_by_default {
              + kms_master_key_id = (known after apply)
              + sse_algorithm     = "aws:kms"
            }
        }
    }

  # module.example-web-s3-mod.aws_s3_bucket_versioning.logging_versioning will be created
  + resource "aws_s3_bucket_versioning" "logging_versioning" {
      + bucket = (known after apply)
      + id     = (known after apply)

      + versioning_configuration {
          + mfa_delete = (known after apply)
          + status     = "Enabled"
        }
    }

  # module.example-web-s3-mod.aws_s3_bucket_versioning.web_s3_versioning will be created
  + resource "aws_s3_bucket_versioning" "web_s3_versioning" {
      + bucket = (known after apply)
      + id     = (known after apply)

      + versioning_configuration {
          + mfa_delete = (known after apply)
          + status     = "Enabled"
        }
    }

Plan: 22 to add, 0 to change, 0 to destroy.

```